### PR TITLE
Remove honouree from relation.ttl

### DIFF
--- a/data/vocab/relation.ttl
+++ b/data/vocab/relation.ttl
@@ -1429,13 +1429,6 @@ rel:honoree a rdf:Property ;
     owl:sameAs lcrel:hnr ;
     rdfs:subPropertyOf lite:contributor .
 
-rel:honouree a rdf:Property ;
-    rdfs:label "honouree"@en ;
-    rdfs:comment "Person, family, or organization honored by a work or item, particularly in British English."@en ;
-    rdfs:domain lite:Resource ;
-    rdfs:range lite:Resource ;
-    rdfs:subPropertyOf lite:contributor .
-
 rel:honoureeOfItem a rdf:Property ;
     rdfs:label "honouree of item"@en ;
     rdfs:comment "Person, family, or organization specifically honored by a particular item or resource."@en ;


### PR DESCRIPTION
We don't create duplicate properties for British English spellings of things, that's better handled through a translation to British English. We use the English version of this property, rel:honoree