### PR TITLE
Delete 'wasDerivedFrom' property from scholar.ttl

### DIFF
--- a/data/vocab/scholar.ttl
+++ b/data/vocab/scholar.ttl
@@ -517,13 +517,6 @@ scholar:fwciTop a rdf:Property ;
     rdfs:range rdfs:Literal ;
     rdfs:domain lite:Person .
 
-scholar:wasDerivedFrom a rdf:Property ;
-    rdfs:label "was derived from"@en ;
-    rdfs:comment "refers to the id of the origin Person from which this data was derived post disambiguation processing"@en ;
-    rdfs:range rdfs:Literal ;
-    owl:sameAs prov:wasDerivedFrom ;
-    rdfs:domain lite:Person .
-
 ## ID properties
 
 scholar:fainId a rdf:Property ;


### PR DESCRIPTION
Removed the 'wasDerivedFrom' property related to Person.